### PR TITLE
No longer requires cloning modules after deserialization (Jetbrains/Kotlin#4727)

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -27,7 +27,7 @@ object Constants {
 // Versions of dependencies
 object Versions {
     const val project = "1.6.1"
-    const val kotlin = "1.6.10"
+    const val kotlin = "1.7.0-Beta"
     const val serializationJSON = "1.3.2"
     const val asm = "9.2"
     const val detekt = "1.19.0"

--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -27,7 +27,7 @@ object Constants {
 // Versions of dependencies
 object Versions {
     const val project = "1.6.1"
-    const val kotlin = "1.7.0-Beta"
+    const val kotlin = "1.7.0"
     const val serializationJSON = "1.3.2"
     const val asm = "9.2"
     const val detekt = "1.19.0"

--- a/src/main/kotlin/com/grappenmaker/solarpatcher/AgentMain.kt
+++ b/src/main/kotlin/com/grappenmaker/solarpatcher/AgentMain.kt
@@ -61,7 +61,7 @@ fun premain(arg: String?, inst: Instrumentation) {
         println("An IO error occured when loading the config, error is above")
         println("Falling back to default config")
         Configuration()
-    }.modulesClone() // TODO: remove, see modulesClone function
+    }
 
     // Define transforms and visitors
     val transforms = configuration.modules.also {

--- a/src/main/kotlin/com/grappenmaker/solarpatcher/config/Configuration.kt
+++ b/src/main/kotlin/com/grappenmaker/solarpatcher/config/Configuration.kt
@@ -101,22 +101,6 @@ data class Configuration(
         .filter { it.visibility == KVisibility.PUBLIC }
         .map { it(this) }
         .filterIsInstance<Module>().filter { it.isEnabled || enableAll } + alwaysEnabledModules
-
-    // TODO: remove when kotlinx.serialization gets fixed
-    // See https://github.com/JetBrains/kotlin/pull/4727
-    fun modulesClone(): Configuration {
-        val cloneFun = this::copy
-        return cloneFun.callBy(cloneFun.parameters.filter {
-            it.typeClass?.java?.let { c -> Module::class.java.isAssignableFrom(c) } == true
-        }.associateWith { param ->
-            val clazz = param.typeClass!!
-            val func = clazz.functions.find { f -> f.name == "copy" } ?: error("No copy for $clazz?")
-            val instance = Configuration::class.memberProperties
-                .find { it.name == param.name }!!.get(this)
-
-            func.callBy(mapOf(func.instanceParameter!! to instance))
-        })
-    }
 }
 
 private val KParameter.typeClass get() = type.classifier as? KClass<*>

--- a/src/main/kotlin/com/grappenmaker/solarpatcher/config/Configuration.kt
+++ b/src/main/kotlin/com/grappenmaker/solarpatcher/config/Configuration.kt
@@ -102,5 +102,3 @@ data class Configuration(
         .map { it(this) }
         .filterIsInstance<Module>().filter { it.isEnabled || enableAll } + alwaysEnabledModules
 }
-
-private val KParameter.typeClass get() = type.classifier as? KClass<*>

--- a/src/main/kotlin/com/grappenmaker/solarpatcher/modules/RuntimeData.kt
+++ b/src/main/kotlin/com/grappenmaker/solarpatcher/modules/RuntimeData.kt
@@ -315,10 +315,10 @@ fun findMethodFromClass(loader: () -> ClassNode?, condition: (MethodNode) -> Boo
     object : ReadOnlyProperty<Any, MethodInfo?> {
         private var method: MethodInfo? = null
 
-        override fun getValue(thisRef: Any, prop: KProperty<*>): MethodInfo? {
+        override fun getValue(thisRef: Any, property: KProperty<*>): MethodInfo? {
             if (method != null) return method
 
-            val owner = loader() ?: error("No class was found when finding a method for ${prop.name}!")
+            val owner = loader() ?: error("No class was found when finding a method for ${property.name}!")
             return owner.methods.find(condition)?.let { MethodInfo(owner, it) }?.also { method = it }
         }
     }


### PR DESCRIPTION
Simple change, but it makes me feel a lot better about myself since I now finally removed this dirty hack. Will merge after kotlin 1.7.0 is published.
